### PR TITLE
Add npm deploy script for Firebase hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,10 @@ The app will open at [http://localhost:3000](http://localhost:3000). When you la
 If you want to deploy on Firebase Hosting:
 
 ```bash
-npm run build
-firebase deploy
+npm run deploy
 ```
 
-Make sure you have the Firebase CLI installed (`npm install -g firebase-tools`) and are logged into your Firebase project.
+This script runs `npm run build` followed by `firebase deploy`. Make sure you have the Firebase CLI installed (`npm install -g firebase-tools`) or available via `npx firebase-tools`, and that you are logged into your Firebase project before running the command.
 
 ## Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "deploy": "npm run build && firebase deploy"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
## Summary
- add an npm `deploy` script that builds and runs `firebase deploy`
- update the README deployment section to reference the new script and note Firebase CLI requirements

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d8e6e747ec83278a15f89b3762aed5