### PR TITLE
Ensure Firebase deploy builds latest app

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,10 @@ The app will open at [http://localhost:3000](http://localhost:3000). When you la
 If you want to deploy on Firebase Hosting:
 
 ```bash
-npm run build
-firebase deploy
+npm run deploy
 ```
 
-Make sure you have the Firebase CLI installed (`npm install -g firebase-tools`) and are logged into your Firebase project.
+This wraps `firebase deploy`. The Firebase config automatically runs `npm run build` before every deploy, so the latest production build is always published. Make sure you have the Firebase CLI installed (`npm install -g firebase-tools`) or available via `npx firebase-tools`, and that you are logged into your Firebase project before running the command. If you prefer to call the CLI directly, `firebase deploy` will run the same predeploy build hook.
 
 ## Troubleshooting
 

--- a/firebase.json
+++ b/firebase.json
@@ -11,6 +11,9 @@
         "source": "**",
         "destination": "/index.html"
       }
+    ],
+    "predeploy": [
+      "npm run build"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "deploy": "firebase deploy"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
## Summary
- add a Firebase Hosting predeploy hook to always build before deploying
- simplify the npm deploy script now that the build runs via the hosting hook
- update the README to explain that firebase deploy automatically builds

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68d8e6e747ec83278a15f89b3762aed5