### PR TITLE
Add favicon link to prevent 404 error

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" href="/favicon.ico" />
     <title>Chore Champions</title>
     <script src="https://cdn.tailwindcss.com"></script>
   </head>

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <title>Chore Champions</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- add an explicit favicon link in the CRA public index.html so the build copies the icon
- mirror the favicon reference in the root index.html used for static hosting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68da4e1144a48327864247cf305416c6