### PR TITLE
feat(kids): add /kids/:kidId detail page with tabs

### DIFF
--- a/src/data/selectors.js
+++ b/src/data/selectors.js
@@ -12,45 +12,69 @@ export function _read(key, def = []) {
   }
 }
 
+const readArray = (source, key) => {
+  if (isArray(source)) return source;
+  if (source && isArray(source.data)) return source.data;
+  if (source && typeof source === 'object') {
+    // Support objects keyed by id (e.g., kidPets in context)
+    const values = Object.values(source).flat();
+    if (values.length > 0) {
+      return values;
+    }
+  }
+  return _read(key);
+};
+
 export function getKids(source) {
   if (isArray(source)) return source;
   if (source && isArray(source.data)) return source.data;
   return _read('kids');
 }
 
-export function getKidById(kidId, source) {
-  if (kidId == null) return null;
+export function getKidById(id, source) {
+  if (id == null) return null;
   const kids = getKids(source);
-  return (
-    kids.find((kid) => String(kid.id) === String(kidId)) || null
-  );
+  return kids.find((kid) => String(kid.id) === String(id)) || null;
 }
 
 export function getChores(source) {
-  if (isArray(source)) return source;
-  if (source && isArray(source.data)) return source.data;
-  return _read('chores');
+  return readArray(source, 'chores');
 }
 
-export function getChoresByKid(kidId, source) {
-  if (kidId == null) return [];
-  return getChores(source).filter((chore) =>
-    String(chore.kidId ?? chore.assignedTo ?? '') === String(kidId)
-  );
+export function getChoresByKid(id, source) {
+  if (id == null) return [];
+  return getChores(source).filter((chore) => String(chore.kidId ?? chore.assignedTo ?? '') === String(id));
 }
 
 export function getRewards(source) {
-  if (isArray(source)) return source;
-  if (source && isArray(source.data)) return source.data;
-  return _read('rewards');
+  return readArray(source, 'rewards');
 }
 
-export function getRewardsByKid(kidId, source) {
-  if (kidId == null) return [];
+export function getRewardsByKid(id, source) {
+  if (id == null) return [];
   return getRewards(source).filter((reward) => {
     const owner = reward?.kidId ?? reward?.redeemedBy ?? reward?.kid ?? reward?.ownerId;
-    return String(owner ?? '') === String(kidId);
+    return String(owner ?? '') === String(id);
   });
+}
+
+export function getPets(source) {
+  return readArray(source, 'pets');
+}
+
+export function getPetsByKid(id, source) {
+  if (id == null) return [];
+  if (source && typeof source === 'object' && !isArray(source)) {
+    const direct = source[id] || source[String(id)];
+    if (isArray(direct)) {
+      return direct;
+    }
+    if (source.data) {
+      const nested = source.data[id] || source.data[String(id)];
+      if (isArray(nested)) return nested;
+    }
+  }
+  return getPets(source).filter((pet) => String(pet.kidId ?? pet.ownerId ?? '') === String(id));
 }
 
 export default {
@@ -60,4 +84,6 @@ export default {
   getChoresByKid,
   getRewards,
   getRewardsByKid,
+  getPets,
+  getPetsByKid,
 };


### PR DESCRIPTION
## Summary
- add tabbed kid detail view with chore grid, rewards list, and pets section
- persist active tab via URL hash and surface kid data via safe selectors

## Testing
- npm run build *(fails: react-scripts not installed because npm install was blocked by registry access errors)*

------
https://chatgpt.com/codex/tasks/task_b_68da6f60f6788327a89d1637e1426923