### PR TITLE
Fix pet evolution when spending coins

### DIFF
--- a/src/pages/Pet.jsx
+++ b/src/pages/Pet.jsx
@@ -198,9 +198,9 @@ export default function Pet() {
                     </Button>
                     <Button
                       onClick={() => handleEvolve(card)}
-                      disabled={card.level >= 5 || card.kid.coins < card.kid.petLevel * 10}
+                      disabled={card.level >= 5 || card.kid.coins < card.level * 10}
                     >
-                      Evolve (-{card.kid.petLevel * 10})
+                      Evolve (-{card.level * 10})
                     </Button>
                     <Button startIcon={<EggIcon />} onClick={() => buyEgg(card.kid.id)} disabled={card.kid.coins < 15}>
                       Buy egg (-15)


### PR DESCRIPTION
## Summary
- ensure pet evolution upgrades whichever companion is shown even when no active pet is set
- update kid record with evolved pet details so future cost and metadata stay in sync
- align evolve button cost display and gating with the pet's actual level

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not installed because npm install cannot resolve file:vendor/three)*
- `npm install` *(fails: lock file references file:vendor/three which npm cannot resolve in this environment)*


------
https://chatgpt.com/codex/tasks/task_b_68dd062277048327bc77adb50599e96f