### PR TITLE
Fix transactional handling for pet evolutions

### DIFF
--- a/src/pages/Pet.jsx
+++ b/src/pages/Pet.jsx
@@ -89,10 +89,11 @@ export default function Pet() {
     const cost = card.level * 10;
     if (!card.activePet || card.kid.coins < cost || card.level >= 5) return;
 
-    const evolved = await upgradePetLevel(card.kid.id);
+    const result = await upgradePetLevel(card.kid.id);
 
-    if (evolved) {
-      showSnackbar(`Evolved to Lv.${Math.min(card.level + 1, 5)}!`);
+    if (result?.success) {
+      const nextLevel = Math.min(result.newLevel ?? card.level + 1, 5);
+      showSnackbar(`Evolved to Lv.${nextLevel}!`);
     } else {
       showSnackbar('Pet could not evolve right now. Try again soon.', 'error');
     }


### PR DESCRIPTION
## Summary
- wrap pet evolution upgrades in a Firestore transaction so coin deductions and pet levels stay in sync, even for legacy pets
- disable the evolve action when no companion is active and show feedback when an evolution attempt fails

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found in environment)*
- `npm run build` *(fails: react-scripts not found in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dd062277048327bc77adb50599e96f